### PR TITLE
Fix/allow zero specification

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -426,20 +426,20 @@ var PS = {};
   var compare = function (dict) {
       return dict.compare;
   };
-  var lessThan = function (dictOrd) {
+  var lessThanOrEq = function (dictOrd) {
       return function (a1) {
           return function (a2) {
               var v = compare(dictOrd)(a1)(a2);
-              if (v instanceof Data_Ordering.LT) {
-                  return true;
+              if (v instanceof Data_Ordering.GT) {
+                  return false;
               };
-              return false;
+              return true;
           };
       };
   };
   exports["Ord"] = Ord;
   exports["compare"] = compare;
-  exports["lessThan"] = lessThan;
+  exports["lessThanOrEq"] = lessThanOrEq;
   exports["ordInt"] = ordInt;
   exports["ordString"] = ordString;
   exports["ordChar"] = ordChar;
@@ -5465,6 +5465,17 @@ var PS = {};
       }
       var result = new Array(count);
       return result.fill(value);
+    };
+  };
+
+  var replicatePolyfill = function (count) {
+    return function (value) {
+      var result = [];
+      var n = 0;
+      for (var i = 0; i < count; i++) {
+        result[n++] = value;
+      }
+      return result;
     };
   };
 
@@ -10669,7 +10680,7 @@ var PS = {};
           return policyTotal < doubleLength;
       };
       var shouldBeAllPositive = function ($11) {
-          return Data_Foldable.all(Data_Foldable.foldableArray)(Data_HeytingAlgebra.heytingAlgebraBoolean)(Data_Ord.lessThan(Data_Ord.ordInt)(0))(arrayFrom($11));
+          return Data_Foldable.all(Data_Foldable.foldableArray)(Data_HeytingAlgebra.heytingAlgebraBoolean)(Data_Ord.lessThanOrEq(Data_Ord.ordInt)(0))(arrayFrom($11));
       };
       return Control_Bind.bind(Data_Either.bindEither)(Control_Bind.bind(Data_Either.bindEither)(Control_Applicative.pure(Data_Either.applicativeEither)(policy))(validate(shouldBeAllPositive)("policy should be all positive")))(validate(shouldBeLongEnough)("policy should be long enough"));
   };

--- a/docs/app.js
+++ b/docs/app.js
@@ -10674,10 +10674,10 @@ var PS = {};
               };
           };
       };
-      var shouldBeLongEnough = function (policy1) {
-          var policyTotal = Data_Foldable.sum(Data_Foldable.foldableArray)(Data_Semiring.semiringInt)(arrayFrom(policy1));
-          var doubleLength = 2 * policy1.length | 0;
-          return policyTotal < doubleLength;
+      var shouldBeLongEnough = function (p) {
+          var policyTotal = Data_Foldable.sum(Data_Foldable.foldableArray)(Data_Semiring.semiringInt)(arrayFrom(p));
+          var doubleLength = 2 * p.length | 0;
+          return policyTotal <= doubleLength;
       };
       var shouldBeAllPositive = function ($11) {
           return Data_Foldable.all(Data_Foldable.foldableArray)(Data_HeytingAlgebra.heytingAlgebraBoolean)(Data_Ord.lessThanOrEq(Data_Ord.ordInt)(0))(arrayFrom($11));

--- a/src/Mkpasswd.purs
+++ b/src/Mkpasswd.purs
@@ -89,7 +89,7 @@ validatePolicy policy =
               if rule target
                   then Right target
                   else Left errMsg
-          shouldBeAllPositive = arrayFrom >>> (all $ (<) 0)
+          shouldBeAllPositive = arrayFrom >>> (all $ (<=) 0)
           shouldBeLongEnough p =
               let policyTotal  = sum $ arrayFrom p
                   doubleLength = 2 * p.length

--- a/src/Mkpasswd.purs
+++ b/src/Mkpasswd.purs
@@ -94,7 +94,7 @@ validatePolicy policy =
               let policyTotal  = sum $ arrayFrom p
                   doubleLength = 2 * p.length
                in
-                  policyTotal < doubleLength
+                  policyTotal <= doubleLength
 
 shuffle :: forall a. Array a -> Effect (Array a)
 shuffle target = catMaybes <$> (shuffleInternal [] target)


### PR DESCRIPTION
文字数指定に0を指定できるようにした[issue #3]

ついでに文字種ごとの最低文字数指定の和と等しい長さ指定をできるようにした