### PR TITLE
記号を文字ごとに使うかどうか選べるようにした

### DIFF
--- a/psc-package.json
+++ b/psc-package.json
@@ -3,6 +3,7 @@
   "set": "psc-0.12.0-20180704",
   "source": "https://github.com/purescript/package-sets.git",
   "depends": [
+    "bifunctors",
     "generics-rep",
     "halogen",
     "routing",

--- a/src/Mkpasswd.purs
+++ b/src/Mkpasswd.purs
@@ -46,7 +46,7 @@ mkpasswd len pol =
     where
           fromCharCodeArray = fromCharArray <<< mapMaybe fromCharCode
           multiChoice n arr = sequence $ replicate n $ choice arr
-          mkpasscode p = catMaybes  <<< join <$> traverse (uncurry multiChoice) p
+          mkpasscode p = shuffle =<< (catMaybes <<< join) <$> traverse (uncurry multiChoice) p
 
 --validatePolicy :: Int -> PasswdPolicy -> Either ErrorReason (Tuple Int PasswdPolicy)
 --validatePolicy length policy =

--- a/src/Mkpasswd.purs
+++ b/src/Mkpasswd.purs
@@ -1,43 +1,16 @@
 module Mkpasswd where
 
-import Prelude
-import Mkpasswd.Data.Ascii
-import Mkpasswd.Data.PasswdPolicy
-import Mkpasswd.Effect.Random
-import Data.Array            ( concat
-                             , (..)
-                             , null
-                             , length
-                             , elem
-                             , all
-                             , (:)
-                             , (!!)
-                             , deleteAt
-                             , replicate
-                             , mapMaybe
-                             , catMaybes
-                             )
+import Prelude  (class Show, join, ($), (<$>), (<<<), (=<<))
+import Mkpasswd.Data.PasswdPolicy (PasswdPolicy, normalize)
+import Mkpasswd.Effect.Random     (choice, shuffle)
+import Data.Array            ( replicate, mapMaybe, catMaybes)
 import Data.Char             ( fromCharCode )
-import Data.Either           ( Either(..) )
-import Data.Foldable         ( sum )
 import Data.Generic.Rep      ( class Generic )
 import Data.Generic.Rep.Show ( genericShow )
-import Data.Maybe            ( Maybe(..), fromMaybe )
 import Data.String.CodeUnits ( fromCharArray )
 import Data.Traversable      ( sequence, traverse )
-import Data.Tuple            ( Tuple(..), fst, snd, uncurry )
+import Data.Tuple            ( uncurry )
 import Effect                ( Effect )
-import Effect.Random         ( randomInt )
-
-
-data ErrorCode
-    = EmptyChars
-    | NoNegative
-    | TooShortLength
-
-derive instance genericErrorReason :: Generic ErrorCode _
-instance showErrorReason :: Show ErrorCode where
-    show = genericShow
 
 mkpasswd :: Int -> Array PasswdPolicy -> Effect String
 mkpasswd len pol =
@@ -47,19 +20,3 @@ mkpasswd len pol =
           fromCharCodeArray = fromCharArray <<< mapMaybe fromCharCode
           multiChoice n arr = sequence $ replicate n $ choice arr
           mkpasscode p = shuffle =<< (catMaybes <<< join) <$> traverse (uncurry multiChoice) p
-
---validatePolicy :: Int -> PasswdPolicy -> Either ErrorReason (Tuple Int PasswdPolicy)
---validatePolicy length policy =
---    pure $ Tuple length policy
---    >>= validate shouldNotBeNothingAll EmptyChars
---    >>= validate shouldBeAllPositive NoNegative
---    >>= validate shouldBeLongEnough  TooShortLength
---    where
---          validate rule errMsg target =
---              if uncarry rule target
---                  then Right target
---                  else Left errMsg
---          shouldNotBeNothingAll _ p =  >>> null >>> not
---          shouldBeAllPositive = policyArray >>> (all $ (<=) 0)
---          shouldBeLongEnough p =
---                  p.length >= (sum $ charTypePolicyArray p)

--- a/src/Mkpasswd.purs
+++ b/src/Mkpasswd.purs
@@ -1,6 +1,9 @@
 module Mkpasswd where
 
 import Prelude
+import Mkpasswd.Data.Ascii
+import Mkpasswd.Data.PasswdPolicy
+import Mkpasswd.Effect.Random
 import Data.Array            ( concat
                              , (..)
                              , null
@@ -21,171 +24,42 @@ import Data.Generic.Rep      ( class Generic )
 import Data.Generic.Rep.Show ( genericShow )
 import Data.Maybe            ( Maybe(..), fromMaybe )
 import Data.String.CodeUnits ( fromCharArray )
-import Data.Traversable      ( sequence )
-import Data.Tuple            ( Tuple(..), fst, snd )
+import Data.Traversable      ( sequence, traverse )
+import Data.Tuple            ( Tuple(..), fst, snd, uncurry )
 import Effect                ( Effect )
 import Effect.Random         ( randomInt )
 
-type PasswdPolicy =
-    { length    :: Int
-    , degit     :: Maybe Int
-    , uppercase :: Maybe Int
-    , lowercase :: Maybe Int
-    , symbol    :: Maybe Int
-    }
 
-defaultPolicy :: PasswdPolicy
-defaultPolicy =
-    { length   : 9
-    , degit    : Just 2
-    , uppercase: Just 2
-    , lowercase: Just 2
-    , symbol   : Just 1
-    }
-
-policyArray :: PasswdPolicy -> Array Int
-policyArray policy = catMaybes
-    [ Just policy.length
-    , policy.degit
-    , policy.uppercase
-    , policy.lowercase
-    , policy.symbol
-    ]
-
-charTypePolicyArray :: PasswdPolicy -> Array Int
-charTypePolicyArray policy = catMaybes
-    [ policy.degit
-    , policy.uppercase
-    , policy.lowercase
-    , policy.symbol
-    ]
-
-ascii :: Tuple Int Int
-ascii = Tuple 0x21 0x7e
-
-degits :: Tuple Int Int
-degits = Tuple 0x30 0x39
-
-uppercaseAlphabetics :: Tuple Int Int
-uppercaseAlphabetics = Tuple 0x41 0x5a
-
-lowercaseAlphabetics :: Tuple Int Int
-lowercaseAlphabetics = Tuple 0x61 0x7a
-
-symbols :: Array Int
-symbols = concat [ 0x21 .. 0x2e, 0x3a .. 0x40, 0x5b .. 0x60, 0x7b .. 0x7e ]
-
-mkpasswd :: PasswdPolicy -> Effect (Either ErrorReason String)
-mkpasswd policy = sequence $ do
-    valiedPolicy <- validatePolicy policy
-    pure $ fromCharCodeArray <$> randomCharCodeArray valiedPolicy
-    where
-          fromCharCodeArray = fromCharArray <<< mapMaybe fromCharCode
-          randomCharCodeArray p =
-              join $ shuffle <$> concat <$> sequence
-                [ randomCharCodes (remainNum p) (randomRemain p)
-                , randomCharCodes (degitNum p) randomDegit
-                , randomCharCodes (uppercaseNum p) randomUpper
-                , randomCharCodes (lowercaseNum p) randomLower
-                , randomCharCodes (symbolNum p) randomSymbol
-                ]
-
-data ErrorReason
+data ErrorCode
     = EmptyChars
     | NoNegative
     | TooShortLength
 
-derive instance genericErrorReason :: Generic ErrorReason _
-instance showErrorReason :: Show ErrorReason where
+derive instance genericErrorReason :: Generic ErrorCode _
+instance showErrorReason :: Show ErrorCode where
     show = genericShow
 
-validatePolicy :: PasswdPolicy -> Either ErrorReason PasswdPolicy
-validatePolicy policy =
-    pure policy
-    >>= validate shouldNotBeNothingAll EmptyChars
-    >>= validate shouldBeAllPositive NoNegative
-    >>= validate shouldBeLongEnough  TooShortLength
+mkpasswd :: Int -> Array PasswdPolicy -> Effect String
+mkpasswd len pol =
+    let policy = normalize len pol
+     in fromCharCodeArray <$> mkpasscode policy
     where
-          validate rule errMsg target =
-              if rule target
-                  then Right target
-                  else Left errMsg
-          shouldNotBeNothingAll = charTypePolicyArray >>> null >>> not
-          shouldBeAllPositive = policyArray >>> (all $ (<=) 0)
-          shouldBeLongEnough p =
-                  p.length >= (sum $ charTypePolicyArray p)
+          fromCharCodeArray = fromCharArray <<< mapMaybe fromCharCode
+          multiChoice n arr = sequence $ replicate n $ choice arr
+          mkpasscode p = catMaybes  <<< join <$> traverse (uncurry multiChoice) p
 
-shuffle :: forall a. Array a -> Effect (Array a)
-shuffle target = catMaybes <$> (shuffleInternal [] target)
-    where
-          shuffleInternal acc []  = pure $ acc
-          shuffleInternal acc arr =
-             let len = length arr
-              in do
-                 idx <- randomInt 0 (len - 1)
-                 let bcc = (arr !! idx) : acc
-                 let brr = fromMaybe [] $ deleteAt idx arr
-                 shuffleInternal bcc brr
-
-randomCharCodes :: Maybe Int -> (Effect Int) -> Effect (Array Int)
-randomCharCodes length randomChar = sequence $ replicate (fromMaybe 0 length) randomChar
-
-degitNum :: PasswdPolicy -> Maybe Int
-degitNum policy = policy.degit
-
-uppercaseNum :: PasswdPolicy -> Maybe Int
-uppercaseNum policy = policy.uppercase
-
-lowercaseNum :: PasswdPolicy -> Maybe Int
-lowercaseNum policy = policy.lowercase
-
-symbolNum :: PasswdPolicy -> Maybe Int
-symbolNum policy = policy.symbol
-
-remainNum :: PasswdPolicy -> Maybe Int
-remainNum policy = Just $ policy.length - (sum $ charTypePolicyArray policy)
-
-randomDegit :: Effect Int
-randomDegit =
-    let top    = snd degits
-        bottom = fst degits
-     in
-        randomInt bottom top
-
-randomUpper :: Effect Int
-randomUpper =
-    let top    = snd uppercaseAlphabetics
-        bottom = fst uppercaseAlphabetics
-     in
-        randomInt bottom top
-
-randomLower :: Effect Int
-randomLower =
-    let top    = snd lowercaseAlphabetics
-        bottom = fst lowercaseAlphabetics
-     in
-        randomInt bottom top
-
-randomCharSelect :: Array Int -> Effect Int
-randomCharSelect popArr =
-    let top    = snd ascii
-        bottom = fst ascii
-     in do
-        chr <- randomInt bottom top
-        if elem chr popArr
-            then pure chr
-            else randomCharSelect popArr
-
-randomSymbol :: Effect Int
-randomSymbol = randomCharSelect symbols
-
-randomRemain :: PasswdPolicy -> Effect Int
-randomRemain = randomCharSelect <<< remainChars
-    where
-          remainChars p = concat $ catMaybes
-              [ map (constCharTypeArr degits) p.degit
-              , map (constCharTypeArr uppercaseAlphabetics) p.uppercase
-              , map (constCharTypeArr lowercaseAlphabetics) p.lowercase
-              , map (const symbols) p.symbol
-              ]
-          constCharTypeArr tpl = const $ (fst tpl) .. (snd tpl)
+--validatePolicy :: Int -> PasswdPolicy -> Either ErrorReason (Tuple Int PasswdPolicy)
+--validatePolicy length policy =
+--    pure $ Tuple length policy
+--    >>= validate shouldNotBeNothingAll EmptyChars
+--    >>= validate shouldBeAllPositive NoNegative
+--    >>= validate shouldBeLongEnough  TooShortLength
+--    where
+--          validate rule errMsg target =
+--              if uncarry rule target
+--                  then Right target
+--                  else Left errMsg
+--          shouldNotBeNothingAll _ p =  >>> null >>> not
+--          shouldBeAllPositive = policyArray >>> (all $ (<=) 0)
+--          shouldBeLongEnough p =
+--                  p.length >= (sum $ charTypePolicyArray p)

--- a/src/Mkpasswd/Data/Ascii.purs
+++ b/src/Mkpasswd/Data/Ascii.purs
@@ -1,0 +1,24 @@
+module Mkpasswd.Data.Ascii where
+
+import Prelude
+import Data.Array            ( concat
+                             , (..)
+                             )
+
+type CharCode = Int
+
+degits :: Array CharCode
+degits = 0x30 .. 0x39
+
+uppercaseAlphabetics :: Array CharCode
+uppercaseAlphabetics = 0x41 .. 0x5a
+
+lowercaseAlphabetics :: Array CharCode
+lowercaseAlphabetics = 0x61 .. 0x7a
+
+symbols :: Array CharCode
+symbols = concat [ 0x21 .. 0x2e
+                 , 0x3a .. 0x40
+                 , 0x5b .. 0x60
+                 , 0x7b .. 0x7e
+                 ]

--- a/src/Mkpasswd/Data/PasswdPolicy.purs
+++ b/src/Mkpasswd/Data/PasswdPolicy.purs
@@ -1,0 +1,47 @@
+module Mkpasswd.Data.PasswdPolicy where
+
+import Prelude
+import Mkpasswd.Data.Ascii
+import Control.Biapplicative ( bipure )
+import Control.Biapply       ( (<<*>>) )
+import Data.Array            ( (:)
+                             , nub
+                             )
+import Data.Foldable         ( foldl )
+import Data.Tuple            ( Tuple, fst, snd )
+
+type RequiredMinNum = Int
+type PasswdPolicy = Tuple RequiredMinNum (Array CharCode)
+
+passwdPolicy :: RequiredMinNum -> Array CharCode -> PasswdPolicy
+passwdPolicy = bipure
+
+defaultLength :: Int
+defaultLength = 9
+
+defaultPolicy :: Array PasswdPolicy
+defaultPolicy =
+    [ passwdPolicy 2 degits
+    , passwdPolicy 2 uppercaseAlphabetics
+    , passwdPolicy 2 lowercaseAlphabetics
+    , passwdPolicy 1 symbols
+    ]
+
+addappend :: PasswdPolicy -> PasswdPolicy -> PasswdPolicy
+addappend a b = bipure (+) (<>) <<*>> a <<*>> b
+
+infixl 5 addappend as <+>
+
+sumPolicy :: Array PasswdPolicy -> PasswdPolicy
+sumPolicy polArr = foldl (<+>) (passwdPolicy 0 []) polArr
+
+minLength :: Array PasswdPolicy -> RequiredMinNum
+minLength p = fst $ sumPolicy p
+
+availableChars :: Array PasswdPolicy -> Array CharCode
+availableChars p = nub $ snd $ sumPolicy p
+
+normalize :: Int -> Array PasswdPolicy -> Array PasswdPolicy
+normalize len polArr =
+    let s = bipure ((-) len) nub <<*>> (sumPolicy polArr)
+     in s : polArr

--- a/src/Mkpasswd/Effect/Random.purs
+++ b/src/Mkpasswd/Effect/Random.purs
@@ -1,0 +1,40 @@
+module Mkpasswd.Effect.Random where
+
+import Prelude
+import Data.Array            ( concat
+                             , (..)
+                             , null
+                             , length
+                             , elem
+                             , all
+                             , (:)
+                             , (!!)
+                             , deleteAt
+                             , replicate
+                             , mapMaybe
+                             , catMaybes
+                             )
+import Data.Maybe            ( Maybe(..), fromMaybe )
+import Data.Traversable      ( sequence )
+import Effect                ( Effect )
+import Effect.Random         ( randomInt )
+
+choice :: forall a. Array a -> Effect (Maybe a)
+choice []     = pure Nothing
+choice popArr =
+    let len = length popArr
+     in do
+        idx <- randomInt 0 (len - 1)
+        pure (popArr !! idx)
+
+shuffle :: forall a. Array a -> Effect (Array a)
+shuffle target = catMaybes <$> (shuffleInternal [] target)
+    where
+          shuffleInternal acc []  = pure $ acc
+          shuffleInternal acc arr =
+             let len = length arr
+              in do
+                 idx <- randomInt 0 (len - 1)
+                 let bcc = (arr !! idx) : acc
+                 let brr = fromMaybe [] $ deleteAt idx arr
+                 shuffleInternal bcc brr


### PR DESCRIPTION
issue #4 の対応続き

生成ロジックは任意の文字セットを任意の数設定できるようにしたが、UI上で文字ごとに選択できるのはとりあえず記号のみとした