### PR TITLE
CSSパッケージのnpm管理移行

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,9 @@
 /.psa*
 /.spago
 /.spec-results
-/docs/app.js
-/docs/app.css
-/docs/*.woff2
+/docs/js/
+/docs/css/
+/docs/fonts/
 
 # IDE Settings
 /.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /.spago
 /.spec-results
 /docs/app.js
+/docs/app.css
 
 # IDE Settings
 /.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /.spec-results
 /docs/app.js
 /docs/app.css
+/docs/*.woff2
 
 # IDE Settings
 /.vscode/

--- a/app/app.css
+++ b/app/app.css
@@ -1,3 +1,6 @@
+@import "@fortawesome/fontawesome-free/css/all.min.css";
+@import "bulma/css/bulma.min.css";
+
 html {
     overflow-y: auto;
 }

--- a/app/app.css
+++ b/app/app.css
@@ -1,0 +1,25 @@
+html {
+    overflow-y: auto;
+}
+html,
+body,
+body>main {
+    height: 100%;
+    margin: 0;
+}
+.mr1 {
+    margin-right: 0.5rem;
+}
+.mb1 {
+    margin-bottom: 0.5rem;
+}
+.p1 {
+    padding: 0.5rem;
+}
+.sticky-bottom {
+    position: sticky;
+    bottom: 0rem;
+}
+.text-wrap {
+    word-break: break-all;
+}

--- a/app/app.js
+++ b/app/app.js
@@ -1,3 +1,4 @@
+import "@fortawesome/fontawesome-free/css/all.min.css";
 import "bulma/css/bulma.min.css";
 import "./app.css";
 import { main } from "../output/Main.SPA/index.js";

--- a/app/app.js
+++ b/app/app.js
@@ -1,0 +1,2 @@
+import { main } from "../output/Main.SPA/index.js";
+main();

--- a/app/app.js
+++ b/app/app.js
@@ -1,2 +1,4 @@
+import "bulma/css/bulma.min.css";
+import "./app.css";
 import { main } from "../output/Main.SPA/index.js";
 main();

--- a/app/app.js
+++ b/app/app.js
@@ -1,5 +1,2 @@
-import "@fortawesome/fontawesome-free/css/all.min.css";
-import "bulma/css/bulma.min.css";
-import "./app.css";
 import { main } from "../output/Main.SPA/index.js";
 main();

--- a/bundle.mjs
+++ b/bundle.mjs
@@ -17,7 +17,7 @@ const ctx = await esbuild.context({
     entryPoints: [`app/app.js`],
     bundle: true,
     platform: 'browser',
-    outfile: 'docs/app.js',
+    outdir: 'docs',
     minify: true,
 });
 

--- a/bundle.mjs
+++ b/bundle.mjs
@@ -19,6 +19,9 @@ const ctx = await esbuild.context({
     platform: 'browser',
     outdir: 'docs',
     minify: true,
+    loader: {
+        ".woff2": "file",
+    },
 });
 
 await ctx.rebuild();

--- a/bundle.mjs
+++ b/bundle.mjs
@@ -14,7 +14,11 @@ const { values: args } = parseArgs({
 });
 
 const ctx = await esbuild.context({
-    entryPoints: [`app/app.js`],
+    // entryPoints をオブジェクトで指定して出力先フォルダを固定する
+    entryPoints: {
+        "js/app": "app/app.js",
+        "css/app": "app/app.css",
+    },
     bundle: true,
     platform: 'browser',
     outdir: 'docs',
@@ -22,6 +26,7 @@ const ctx = await esbuild.context({
     loader: {
         ".woff2": "file",
     },
+    assetNames: 'fonts/[name]',
 });
 
 await ctx.rebuild();

--- a/bundle.mjs
+++ b/bundle.mjs
@@ -5,16 +5,8 @@ import esbuild from "esbuild";
 
 const { values: args } = parseArgs({
     options: {
-        watch: {
-            type: "boolean",
-            multiple: false,
-        },
         serve: {
             type: "boolean",
-            multiple: false,
-        },
-        main: {
-            type: "string",
             multiple: false,
         },
     },
@@ -22,10 +14,7 @@ const { values: args } = parseArgs({
 });
 
 const ctx = await esbuild.context({
-    stdin: {
-        contents: `import { main } from "./output/${args.main}/index.js";main();`,
-        resolveDir: '.'
-    },
+    entryPoints: [`app/app.js`],
     bundle: true,
     platform: 'browser',
     outfile: 'docs/app.js',
@@ -38,12 +27,7 @@ if (args.serve) {
     await ctx.serve({
         servedir: 'docs',
     });
-}
-
-if (args.watch) {
     await ctx.watch();
-}
-
-if (!args.watch && !args.serve) {
+} else {
     await ctx.dispose();
 }

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1,7 +1,0 @@
-* {
-	width: 100%;
-	height: 100%;
-	padding: 0;
-	margin: 0;
-	overflow: hidden;
-}

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,13 +3,13 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="stylesheet" href="app.css">
+<link rel="stylesheet" href="css/app.css">
 <style type="text/css">
 </style>
 <title>mkpasswd</title>
 </head>
 <body class="has-navbar-fixed-top">
-<script src="app.js"></script>
+<script src="js/app.js"></script>
 <script>
 </script>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="app.css">
-<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
 <style type="text/css">
 </style>
 <title>mkpasswd</title>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,34 +3,9 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
+<link rel="stylesheet" href="app.css">
 <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
 <style type="text/css">
-    html {
-        overflow-y: auto;
-    }
-    html,
-    body,
-    body>main {
-        height: 100%;
-        margin: 0;
-    }
-    .mr1 {
-        margin-right: 0.5rem;
-    }
-    .mb1 {
-        margin-bottom: 0.5rem;
-    }
-    .p1 {
-        padding: 0.5rem;
-    }
-    .sticky-bottom {
-        position: sticky;
-        bottom: 0rem;
-    }
-    .text-wrap {
-        word-break: break-all;
-    }
 </style>
 <title>mkpasswd</title>
 </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@fortawesome/fontawesome-free": "^7.1.0",
         "bulma": "^1.0.4"
       },
       "devDependencies": {
@@ -458,6 +459,15 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.1.0.tgz",
+      "integrity": "sha512-+WxNld5ZCJHvPQCr/GnzCTVREyStrAJjisUPtUxG5ngDA8TMlPnKp6dddlTpai4+1GNmltAeuk1hJEkBohwZYA==",
+      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@gar/promisify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "mkpasswdpwa",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "bulma": "^1.0.4"
+      },
       "devDependencies": {
         "esbuild": "^0.25.0",
         "purescript": "^0.15.0",
@@ -992,6 +995,12 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/bulma": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bulma/-/bulma-1.0.4.tgz",
+      "integrity": "sha512-Ffb6YGXDiZYX3cqvSbHWqQ8+LkX6tVoTcZuVB3lm93sbAVXlO0D6QlOTMnV6g18gILpAXqkG2z9hf9z4hCjz2g==",
+      "license": "MIT"
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
     "purescript": "^0.15.0",
     "purs-tidy": "^0.11.0",
     "spago": "^0.93.40"
+  },
+  "dependencies": {
+    "bulma": "^1.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "spago build && node bundle.mjs --main Main.SPA",
+    "prebuild": "spago build",
+    "build": "node bundle.mjs",
     "precli": "spago bundle-app --main Main.CLI --to bin/cli.mjs --minify --platform=node",
     "cli": "node bin/cli.mjs",
-    "serve": "node bundle.mjs --serve --watch --main Main.SPA",
+    "serve": "node bundle.mjs --serve",
     "test": "spago test"
   },
   "author": "amderbar",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "spago": "^0.93.40"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^7.1.0",
     "bulma": "^1.0.4"
   }
 }


### PR DESCRIPTION
## 概要

bulma css や fontawasome は CDN で利用しており package.json とは別管理になっていたため忘れられがちだった。
これを解消するためにこれらを npm 管理に移行した。

## 修正点

- bulma css を npm インストールして自作 css からインポートしバンドルするようにした
- fontawasome を npm インストールして自作 css からインポートしバンドルするようにした
- ビルドスクリプトや出力先ディレクトリ構造を合わせて修正した