### PR TITLE
ci: リリースは手動でやるようにする

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Release
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## 背景

dependabot の PR はパッケージ毎に分かれて出されるが、main にマージしたらすぐデプロイが走る設定だといちいちバージョンアップリリースが行われてしまう
以下のリソースを無駄に消費してしまうと思われる

- アクションの実行時間
- アーティファクト容量

ただ分割されてた方が、おかしくなった時にどのパッケージの更新が原因か分かりやすくなる利点もある

リリース（デプロイ、タグ更新）はある程度まとめて、しかしPR自体は細かく出せるようにしたい

## 変更内容

リリースワークフローのmainブランチへのプッシュトリガーを廃止し、手動実行でのみ起動するようにする

これにより手動作業の手間は増えるが、リリースのタイミングを制御できるようにする