### PR TITLE
Issue #72 deprecation banner for list page

### DIFF
--- a/src/Page/List.purs
+++ b/src/Page/List.purs
@@ -70,7 +70,8 @@ render state =
         [ HH.div
             [ HP.classes $ HH.ClassName <$> [ "container" ] ]
             $ join
-                [ if null state.list then
+                [ [ deprecationBanner ]
+                , if null state.list then
                     emptyListView
                   else
                     mapWithIndex (accountRow state.openMenuIndex) state.list
@@ -78,6 +79,15 @@ render state =
                 ]
         ]
     , csvExportModal state.csvExport
+    ]
+
+deprecationBanner :: forall i p. HH.HTML i p
+deprecationBanner =
+  HH.div
+    [ HP.classes $ HH.ClassName <$> [ "notification", "is-warning", "is-light" ] ]
+    [ HH.p
+        [ HP.classes $ HH.ClassName <$> [ "mb0" ] ]
+        [ HH.text "この機能は将来廃止予定です。保存済みデータはCSV出力で保存し、別ツールへの移行をご検討ください。" ]
     ]
 
 accountRow :: forall i. Maybe Int -> Int -> FormData -> HH.HTML i Action


### PR DESCRIPTION
## 概要
一覧画面（保存済みデータの閲覧・削除）に対して、将来廃止予定であることを利用者へ告知するバナーを追加します。

## 変更
- [src/Page/List.purs](src/Page/List.purs) の一覧画面表示に、Bulma の notification クラスを使った告知メッセージを追加
- 文言は Issue #72 の本文に沿って、CSV 出力への移行を促す案内にしています

## 依存
- 起点は origin/66-deprecation-list-and-save
- CSV 出力済みの現行状態を前提に、一覧画面廃止予定の案内を出す実装です