### PR TITLE
Issue #73: remove list edit affordance

### DIFF
--- a/src/Page/List.purs
+++ b/src/Page/List.purs
@@ -131,8 +131,7 @@ cardMenu mi i =
         [ HP.classes $ HH.ClassName <$> [ "dropdown-menu" ] ]
         [ HH.div
             [ HP.classes $ HH.ClassName <$> [ "dropdown-content" ] ]
-            [ dropdownItem Nothing (ToggleMenu i) "fa-pen-fancy" "edit"
-            , dropdownItem Nothing (Delete i) "fa-trash-alt" "remove"
+            [ dropdownItem Nothing (Delete i) "fa-trash-alt" "remove"
             ]
         ]
     ]


### PR DESCRIPTION
## Summary

This PR removes the edit affordance from the list page dropdown so the list screen behaves as a read-only, delete-only surface.

## Changes

- Removed the menu row that linked the list-card dropdown to the `Store` item for editing.
- Kept the delete menu item intact.

## Verification

- `npm test -- --no-color` passed with `12/12` tests green.